### PR TITLE
Old link to git

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "repositories":[
         {
             "type":"git",
-            "url":"http://github.com/pqr/superlogger"
+            "url":"https://github.com/pqr/superlogger"
         },
 
         {
@@ -12,7 +12,7 @@
                 "version":"1.2.3",
                 "source":{
                     "type":"git",
-                    "url":"http://github.com/pqr/superlib",
+                    "url":"https://github.com/pqr/superlib",
                     "reference":"master"
                 },
                 "autoload":{


### PR DESCRIPTION
Update "repositories" url: https://github.com/pqr/superlogger, https://github.com/pqr/superlib
Composer don't allow connection to old links.